### PR TITLE
Allow user installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,15 @@
 
 ### From PYPI
 
-Run the following command (as root):
+User install:
 
     pip install nautilus_terminal
+    tools/update-extension-user.sh install   # until next stable release
+
+System-wide install:
+
+    sudo pip install nautilus_terminal
+    sudo tools/update-extension-system.sh install   # foreseeable future
 
 Then kill Nautilus to allow it to load the new extension:
 
@@ -50,23 +56,30 @@ Clone the repositiory:
     git clone git@github.com:flozz/nautilus-terminal.git
     cd nautilus-terminal
 
-For testing, run the following as a non-privileged user, so that pip will select the `--user` scheme.  To install for all users, run the command as root instead.
+To install into your personal Python lib and your personal Nautilus python extension folders, run the following from your normal unprivileged account. Pip will select the `--user` scheme.
 
     pip install .
+
+To install for all users, run the command as root instead. Pip will select the `--system` scheme if you install this way. This drops everything into `/usr/local` instead, but nautilus-python doesn't look there for extensions (see upstream [bug 781232][]). So for the foreseeable future, system-wide installs need an extra step to make the extension available for all users.
+
+    sudo pip install .
+    sudo tools/update-extension-system.sh install
 
 Then kill Nautilus to allow it to load the new extension:
 
     nautilus -q
 
-**NOTE:** if the setup fails to install the Nautilus Python extension script, you can copy it manually (as root):
-
-    cp nautilus_terminal/nautilus_terminal_extension.py /usr/share/nautilus-python/extensions/
+## Uninstalling
 
 To uninstall the package, run:
 
     pip uninstall nautilus-terminal
+    tools/update-extension-user.sh uninstall   # new pip (9.0.1) handles this for installs from source
 
-as the same user you installed it with.
+If you installed it for all users:
+
+    sudo pip uninstall nautilus-terminal
+    sudo tools/update-extension-system.sh uninstall   # foreseeable future
 
 ## Hacking and Debug
 
@@ -76,7 +89,7 @@ If you want work on this software, you will first have to install the [nautilus-
 
 If you installed as root, you have to copy the `nautilus_terminal_extension.py` file in the nautilus-python's extension folder (this script is just a minimal bootstrap that will import the `nautilus_terminal` module installed system wild or the one located in this repository if the right debug environment is set). This can be done by one of the script of the `tools/` folder:
 
-    ./tools/update-locale-extention.sh
+    sudo tools/update-extension-system.sh install
 
 You can now hack Nautilus Terminal as you want and you can use the following script to test your code right into nautilus:
 
@@ -119,3 +132,4 @@ Happy hacking! :)
 [old-nterm]: https://launchpad.net/nautilus-terminal
 [nautilus-python]: https://wiki.gnome.org/Projects/NautilusPython/
 [psutil]: https://pypi.python.org/pypi/psutil/
+[bug 781232]: https://bugzilla.gnome.org/show_bug.cgi?id=781232

--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ Clone the repositiory:
     git clone git@github.com:flozz/nautilus-terminal.git
     cd nautilus-terminal
 
-Install Nautilus Terminal (as root):
+For testing, run the following as a non-privileged user, so that pip will select the `--user` scheme.  To install for all users, run the command as root instead.
 
-    python setup.py install
+    pip install .
 
 Then kill Nautilus to allow it to load the new extension:
 
@@ -62,6 +62,11 @@ Then kill Nautilus to allow it to load the new extension:
 
     cp nautilus_terminal/nautilus_terminal_extension.py /usr/share/nautilus-python/extensions/
 
+To uninstall the package, run:
+
+    pip uninstall nautilus-terminal
+
+as the same user you installed it with.
 
 ## Hacking and Debug
 
@@ -69,7 +74,7 @@ If you want work on this software, you will first have to install the [nautilus-
 
     sudo apt install python-nautilus python-psutil
 
-Then you have to copy the `nautilus_terminal_extension.py` file in the nautilus-python's extension folder (this script is just a minimal bootstrap that will import the `nautilus_terminal` module installed system wild or the one located in this repository if the right debug environment is set). This can be done by one of the script of the `tools/` folder:
+If you installed as root, you have to copy the `nautilus_terminal_extension.py` file in the nautilus-python's extension folder (this script is just a minimal bootstrap that will import the `nautilus_terminal` module installed system wild or the one located in this repository if the right debug environment is set). This can be done by one of the script of the `tools/` folder:
 
     ./tools/update-locale-extention.sh
 

--- a/README.md
+++ b/README.md
@@ -87,14 +87,17 @@ If you want work on this software, you will first have to install the [nautilus-
 
     sudo apt install python-nautilus python-psutil
 
-If you installed as root, you have to copy the `nautilus_terminal_extension.py` file in the nautilus-python's extension folder (this script is just a minimal bootstrap that will import the `nautilus_terminal` module installed system wild or the one located in this repository if the right debug environment is set). This can be done by one of the script of the `tools/` folder:
+This extension comes in two parts: a conventional Python module (`nautilus_terminal`), and a small bit of bootstrap code that's loaded by `python-nautilus` when Nautilus starts up (`nautilus_terminal_extension.py`). The bootstrap code must be installed where `python-nautilus` can find it before you can start making changes and testing them:
 
-    sudo tools/update-extension-system.sh install
+    tools/update-extension-user.sh install        # Current user only…
+    sudo tools/update-extension-system.sh install  # … or, system-wide.
 
-You can now hack Nautilus Terminal as you want and you can use the following script to test your code right into nautilus:
+When the bootstrap is loaded into Nautilus, it imports the Python module from either the normal `PYTHONPATH`, or from your working copy of this repository if the right debug environment is set.
 
-    ./tools/debug-in-nautilus.sh
-    ./tools/debug-in-nautilus.sh --no-bg  # keep Nautilus attached to the console
+With the bootstrap installed, you can use the following script to test new code in Nautilus without having to reinstall the module:
+
+    tools/debug-in-nautilus.sh
+    tools/debug-in-nautilus.sh --no-bg  # keep Nautilus attached to the console
 
 Happy hacking! :)
 

--- a/setup.py
+++ b/setup.py
@@ -2,31 +2,27 @@
 # encoding: UTF-8
 
 import os
-import shutil
 from setuptools import setup, find_packages
 from setuptools.command.install import install as _install
 
 from nautilus_terminal import VERSION
 
 
-NAUTILUS_PYTHON_EXTENSION_PATH = "/usr/share/nautilus-python/extensions"
-
-
 class install(_install):
     def run(self):
         _install.run(self)
+
+        # Do what distutils install_data used to do... *sigh*
+        # Despite what the setuptools docs say, the omission of this
+        # in setuptools is a bug, not a feature.
         print("Installing Nautilus Python extension...")
-        if not os.path.isdir(NAUTILUS_PYTHON_EXTENSION_PATH):
-            try:
-                os.mkdir(NAUTILUS_PYTHON_EXTENSION_PATH)
-            except OSError:
-                print("WARNING: Nautilus Python extension have not been installed (%s cannot be created)" % NAUTILUS_PYTHON_EXTENSION_PATH)
-                return
-        try:
-            shutil.copy("./nautilus_terminal/nautilus_terminal_extension.py", NAUTILUS_PYTHON_EXTENSION_PATH)
-        except IOError:
-            print("WARNING: Nautilus Python extension have not been installed (permission denied)")
-            return
+        src_file = "nautilus_terminal/nautilus_terminal_extension.py"
+        dst_dir = os.path.join(
+            self.install_data, "share/nautilus-python/extensions",
+        )
+        self.mkpath(dst_dir)
+        dst_file = os.path.join(dst_dir, os.path.basename(src_file))
+        self.copy_file(src_file, dst_file)
         print("Done!")
 
 
@@ -55,4 +51,3 @@ setup(
 
     cmdclass={"install": install}
 )
-

--- a/tools/update-extension-system.sh
+++ b/tools/update-extension-system.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Make the extension available to all users.
+#
+# The Python integration for Nautilus doesn't seem to respect /usr/local
+# prefixes despite its docs saying it should. For now, global installs
+# need the extension module to go in the /usr location only.
+
+SRC=nautilus_terminal/nautilus_terminal_extension.py
+TARGDIR=/usr/share/nautilus-python/extensions
+
+bn=`basename "$SRC"`
+
+case "$1" in
+    install)
+        mkdir -v -p -m 0755 "$TARGDIR"
+        cp -v "$SRC" "$TARGDIR/$bn"
+        chmod -c 0644 "$TARGDIR/$bn"
+        ;;
+    uninstall)
+        rm -vf "$TARGDIR/$bn"
+        ;;
+    *)
+        echo >&2 "usage: $0 {install|uninstall}"
+        ;;
+esac

--- a/tools/update-extension-user.sh
+++ b/tools/update-extension-user.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Make the extension available to the current user.
+
+SRC=nautilus_terminal/nautilus_terminal_extension.py
+TARGDIR=~/.local/share/nautilus-python/extensions
+
+bn=`basename "$SRC"`
+
+case "$1" in
+    install)
+        mkdir -v -p "$TARGDIR"
+        cp -v "$SRC" "$TARGDIR/$bn"
+        ;;
+    uninstall)
+        rm -vf "$TARGDIR/$bn"
+        ;;
+    *)
+        echo >&2 "usage: $0 {install|uninstall}"
+        ;;
+esac

--- a/tools/update-locale-extention.sh
+++ b/tools/update-locale-extention.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-
-mkdir -p ~/.local/share/nautilus-python/extensions/
-cp nautilus_terminal/nautilus_terminal_extension.py ~/.local/share/nautilus-python/extensions/


### PR DESCRIPTION
This commit allows pip-manged installs using the user scheme, and updates the docs a bit accordingly. Specifically it enables

    $ pip install .   # as a non-root user
    $ python setup.py install --user

And if you use pip to install, you can use pip to uninstall. Since this works quite neatly, I've updated the docs to suggest that as the normal way of doing things.