### PR TITLE
Use the user's choice of shell, not zsh

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 * Supports copy / paste from / to the terminal using `Ctrl+Shift+C` / `Ctrl+Shift+V`,
 * Can be displayed / hidden using the `F4` key,
 * Supports drag & drop of file on the terminal,
-* ~~Allows to configure the shell~~ **TODO** (actually it is hardcoded to `/bin/zsh`),
+* Uses the correct login shell for the user.
 * ~~Allows to configure the terminal appearance (colors, font,...).~~ **TODO**
 
 **Requirements:**

--- a/nautilus_terminal/nautilus_terminal.py
+++ b/nautilus_terminal/nautilus_terminal.py
@@ -1,5 +1,6 @@
 import os
 import signal
+import pwd
 
 from gi.repository import GLib, Gio, Gtk, Gdk, Vte
 
@@ -259,9 +260,12 @@ class NautilusTerminal(object):
 
     def _spawn_shell(self):
         if self._shell_pid:
-            logger.warn("NautilusTerminal._spawn_shell: Cannot swpawn a new shell: there is already a shell running...")
+            logger.warn(
+                "NautilusTerminal._spawn_shell: Cannot spawn a new shell: "
+                "there is already a shell running."
+            )
             return
-        shell = "/bin/zsh"  # TODO make this configurable
+        shell = pwd.getpwuid(os.getuid()).pw_shell
         _, self._shell_pid = self._ui_terminal.spawn_sync(
                 Vte.PtyFlags.DEFAULT, self._cwd, [shell],
                 None, GLib.SpawnFlags.SEARCH_PATH, None, None)


### PR DESCRIPTION
I'm a bash user, so hardcoded zsh is a deal breaker for me. The right thing to do is figure out a user's login shell and use that. Now everyone's happy by default.