### PR TITLE
Enhance child process searching with method psutil.Process(pid).children()

### DIFF
--- a/nautilus_terminal/helpers.py
+++ b/nautilus_terminal/helpers.py
@@ -13,10 +13,7 @@ def gvfs_uri_to_path(uri):
 
 
 def process_has_child(pid):
-    if psutil.Process(pid).children():
-        return True
-    else:
-        return False
+    return len(psutil.Process(pid).children()) > 0
 
 
 def get_process_cwd(pid):

--- a/nautilus_terminal/helpers.py
+++ b/nautilus_terminal/helpers.py
@@ -13,10 +13,10 @@ def gvfs_uri_to_path(uri):
 
 
 def process_has_child(pid):
-    for process in psutil.process_iter():
-        if process.ppid() == pid:
-            return True
-    return False
+    if psutil.Process(pid).children():
+        return True
+    else:
+        return False
 
 
 def get_process_cwd(pid):


### PR DESCRIPTION
Like the title said.

Tested with this scenario :
1. Launching nautilus in debug mode : ```NAUTILUS_TERMINAL_DEBUG=true nautilus```
2. Execute ```gnome-calculator``` inside the embedded nautilus terminal.
3. Changing directory inside nautilus
4. Expecting the debug message : ```[Nautilus Terminal][ LOG] NautilusTerminal.change_directory: current directory NOT changed to /path/to/change (shell busy)```
5. Close/Kill ```gnome-calculator```
6. Changing directory inside nautilus
7. Expecting the debug message ```[Nautilus Terminal][ LOG] NautilusTerminal._inject_command:  cd '/path/to/change'``` and the directory has changed correctly in the embedded nautilus terminal