### PR TITLE
fixed auto-cd bug by cmd conversion from str to utf-8

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,8 @@ Things to do before releasing a new version:
 
 ## Changelog
 
+* **3.2.3:**
+    * Fixes `VteTerminal.feed_child()` call by conversion from str to utf-8
 * **3.2.2:**
     * Fixes `VteTerminal.feed_child()` call (#12)
     * Improves child process searching (@l-deniau, #14)

--- a/nautilus_terminal/__init__.py
+++ b/nautilus_terminal/__init__.py
@@ -1,2 +1,2 @@
-VERSION = "3.2.2"
+VERSION = "3.2.3"
 APPLICATION_ID = "org.flozz.nautilus-terminal"

--- a/nautilus_terminal/nautilus_terminal.py
+++ b/nautilus_terminal/nautilus_terminal.py
@@ -24,7 +24,7 @@ def _vte_terminal_feed_child(vte_terminal, text):
         return vte_terminal.feed_child(text, len(text) + 1)
     except TypeError:
         # Newer call
-        return vte_terminal.feed_child(text)
+        return vte_terminal.feed_child(text.encode('utf-8'))
 
 
 def _find_nautilus_terminal_vpanel(crowbar):


### PR DESCRIPTION
Hey @flozz,
just came about this nice plugin but encountered a auto-cd-dir problem in current arch 
```
[...]
  File "[...]nautilus-terminal/nautilus_terminal/nautilus_terminal.py", line 27, in _vte_terminal_feed_child
    return vte_terminal.feed_child(text)
TypeError: Must be number, not str
```
Fix included, but I'm unsure if it breaks downward compatibility. Please review!
Best, Martin