### PR TITLE
Add custom font option

### DIFF
--- a/nautilus_terminal/nautilus_terminal.py
+++ b/nautilus_terminal/nautilus_terminal.py
@@ -5,7 +5,7 @@ import sys
 import gi
 gi.require_version("Vte", "2.91")  # noqa
 
-from gi.repository import GLib, Gio, Gtk, Gdk, Vte
+from gi.repository import GLib, Gio, Gtk, Gdk, Vte, Pango
 
 from . import logger
 from . import helpers
@@ -213,6 +213,10 @@ class NautilusTerminal(object):
         # our GtkPaned.
 
         self._ui_terminal = Vte.Terminal()
+
+        settings_font = self._settings.get_string("custom-font")
+        self._ui_terminal.set_font(Pango.FontDescription(settings_font))
+
         self._ui_terminal.connect("child-exited", self._on_terminal_child_existed)
         if self._terminal_bottom:
             self._ui_vpanel.pack2(self._ui_terminal, resize=False, shrink=False)

--- a/nautilus_terminal/schemas/org.flozz.nautilus-terminal.gschema.xml
+++ b/nautilus_terminal/schemas/org.flozz.nautilus-terminal.gschema.xml
@@ -41,5 +41,10 @@
       <summary>Terminal text color</summary>
       <description>The color of the terminal text (Hexadecimal notation. E.g. "#FFFFFF", "white")</description>
     </key>
+    <key name="custom-font" type="s">
+      <default>""</default>
+      <summary>A Pango font description</summary>
+      <description>String representation of a Pango font description (e.g. "DejaVu Sans Mono 10")</description>
+    </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
Added new option for custom font using Pango font description string. It supports font family, style, size and other font options. 
This new option covers #10 issue.  