### PR TITLE
Make init focus optional and set it disabled by default

### DIFF
--- a/nautilus_terminal/nautilus_terminal.py
+++ b/nautilus_terminal/nautilus_terminal.py
@@ -100,6 +100,9 @@ class NautilusTerminal(object):
         self._terminal_requested_visibility = self._settings.get_boolean(
             "default-show-terminal"
         )
+        self._terminal_focus_on_init = self._settings.get_boolean(
+            "default-focus-terminal"
+        )
         self._terminal_bottom = self._settings.get_boolean("terminal-bottom")
         self._nterm_action_group = None
         self._ntermwin_action_group = None
@@ -116,7 +119,7 @@ class NautilusTerminal(object):
 
         # Set if the terminal should be visible by default.
         # Will spawn the shell automatically if the terminal is visible
-        self.set_terminal_visible(self._terminal_requested_visibility)
+        self.set_terminal_visible(self._terminal_requested_visibility, self._terminal_focus_on_init)
 
     def change_directory(self, path):
         # "virtual" location (trash:///, network:///,...)

--- a/nautilus_terminal/nautilus_terminal.py
+++ b/nautilus_terminal/nautilus_terminal.py
@@ -119,7 +119,9 @@ class NautilusTerminal(object):
 
         # Set if the terminal should be visible by default.
         # Will spawn the shell automatically if the terminal is visible
-        self.set_terminal_visible(self._terminal_requested_visibility, self._terminal_focus_on_init)
+        self.set_terminal_visible(
+            self._terminal_requested_visibility, self._terminal_focus_on_init
+        )
 
     def change_directory(self, path):
         # "virtual" location (trash:///, network:///,...)

--- a/nautilus_terminal/schemas/org.flozz.nautilus-terminal.gschema.xml
+++ b/nautilus_terminal/schemas/org.flozz.nautilus-terminal.gschema.xml
@@ -46,5 +46,10 @@
       <summary>A Pango font description</summary>
       <description>String representation of a Pango font description (e.g. "DejaVu Sans Mono 10")</description>
     </key>
+    <key name="default-focus-terminal" type="b">
+      <default>false</default>
+      <summary>Is Nautilus Terminal focused in new Nautilus windows</summary>
+      <description>Enabled "default-show-terminal" is required</description>
+    </key>
   </schema>
 </schemalist>


### PR DESCRIPTION
I think in #37 man has a really good point about stealing focus on start. In most cases it will break UX for users who use keyboard for navigation in Nautilus and it's kinda opposite of Gnome way.

So I added new option for initial focus and disabled it by default. I hope you don't mind =)    