### PR TITLE
Feature/auto clean

### DIFF
--- a/nautilus_terminal/nautilus_terminal.py
+++ b/nautilus_terminal/nautilus_terminal.py
@@ -104,6 +104,7 @@ class NautilusTerminal(object):
             "default-focus-terminal"
         )
         self._terminal_bottom = self._settings.get_boolean("terminal-bottom")
+        self._auto_clean = self._settings.get_enum("auto-clean")
         self._nterm_action_group = None
         self._ntermwin_action_group = None
         self._shell_pid = 0
@@ -167,9 +168,28 @@ class NautilusTerminal(object):
             "NautilusTerminal.change_directory: current directory changed to %s"
             % path
         )
-        self._inject_command(
-            " cd %s" % helpers.escape_path_for_shell(self._cwd)
-        )
+
+        command = " cd %s" % helpers.escape_path_for_shell(self._cwd)
+        if self.get_auto_clean() == 2:
+            command += " && clear "
+
+        # Cut current user input to clipboard
+        self.stash_current_termianl_content()
+
+        self._inject_command(command)
+
+        if self.get_auto_clean() == 1:
+            self._emit_key_press("l", Gdk.ModifierType.CONTROL_MASK)
+
+
+    def stash_current_termianl_content(self):
+        # move to the end of line in terminal
+        self._emit_key_press("e", Gdk.ModifierType.CONTROL_MASK)
+        # cut all content in line to the left
+        self._emit_key_press("u", Gdk.ModifierType.CONTROL_MASK)
+
+    def get_auto_clean(self):
+        return self._auto_clean
 
     def get_terminal_requested_visibility(self):
         """Does the user requested the terminal to be visible?
@@ -210,6 +230,14 @@ class NautilusTerminal(object):
     def _inject_command(self, command):
         logger.log("NautilusTerminal._inject_command: %s" % command)
         _vte_terminal_feed_child(self._ui_terminal, "%s\n" % command)
+
+    def _emit_key_press(self, key, state=0):
+        event = Gdk.Event().new(Gdk.EventType.KEY_PRESS)
+        event.state = state
+        event.keyval = Gdk.keyval_from_name(key)
+        event.window = self._ui_terminal.get_window()
+        event.send_event = True
+        self._ui_terminal.emit("key-press-event", event)
 
     def update_ui(self):
         for widget in self._parent_widget:

--- a/nautilus_terminal/nautilus_terminal.py
+++ b/nautilus_terminal/nautilus_terminal.py
@@ -181,7 +181,6 @@ class NautilusTerminal(object):
         if self.get_auto_clean() == 1:
             self._emit_key_press("l", Gdk.ModifierType.CONTROL_MASK)
 
-
     def stash_current_termianl_content(self):
         # move to the end of line in terminal
         self._emit_key_press("e", Gdk.ModifierType.CONTROL_MASK)

--- a/nautilus_terminal/nautilus_terminal.py
+++ b/nautilus_terminal/nautilus_terminal.py
@@ -19,7 +19,8 @@ _EXPAND_WIDGETS = [
     "NautilusViewIconController",
     "NautilusListView",
 ]
-
+_AUTO_CLEAN_SOFT = 1
+_AUTO_CLEAN_HARD = 2
 
 def _vte_terminal_feed_child(vte_terminal, text):
     if sys.version_info.major >= 3:
@@ -169,16 +170,16 @@ class NautilusTerminal(object):
             % path
         )
 
-        command = " cd %s" % helpers.escape_path_for_shell(self._cwd)
-        if self.get_auto_clean() == 2:
-            command += " && clear "
+        command = " cd %s " % helpers.escape_path_for_shell(self._cwd)
+        if self.get_auto_clean() == _AUTO_CLEAN_HARD:
+            command += "&& clear "
 
         # Cut current user input to clipboard
         self.stash_current_termianl_content()
 
         self._inject_command(command)
 
-        if self.get_auto_clean() == 1:
+        if self.get_auto_clean() == _AUTO_CLEAN_SOFT:
             self._emit_key_press("l", Gdk.ModifierType.CONTROL_MASK)
 
     def stash_current_termianl_content(self):

--- a/nautilus_terminal/nautilus_terminal.py
+++ b/nautilus_terminal/nautilus_terminal.py
@@ -22,6 +22,7 @@ _EXPAND_WIDGETS = [
 _AUTO_CLEAN_SOFT = 1
 _AUTO_CLEAN_HARD = 2
 
+
 def _vte_terminal_feed_child(vte_terminal, text):
     if sys.version_info.major >= 3:
         text = text.encode("utf-8")
@@ -106,6 +107,9 @@ class NautilusTerminal(object):
         )
         self._terminal_bottom = self._settings.get_boolean("terminal-bottom")
         self._auto_clean = self._settings.get_enum("auto-clean")
+        self._auto_cut_user_input = self._settings.get_boolean(
+            "auto-cut-user-input"
+        )
         self._nterm_action_group = None
         self._ntermwin_action_group = None
         self._shell_pid = 0
@@ -174,8 +178,8 @@ class NautilusTerminal(object):
         if self.get_auto_clean() == _AUTO_CLEAN_HARD:
             command += "&& clear "
 
-        # Cut current user input to clipboard
-        self.stash_current_termianl_content()
+        if self.get_auto_cut_user_input():
+            self.stash_current_termianl_content()
 
         self._inject_command(command)
 
@@ -187,6 +191,9 @@ class NautilusTerminal(object):
         self._emit_key_press("e", Gdk.ModifierType.CONTROL_MASK)
         # cut all content in line to the left
         self._emit_key_press("u", Gdk.ModifierType.CONTROL_MASK)
+
+    def get_auto_cut_user_input(self):
+        return self._auto_cut_user_input
 
     def get_auto_clean(self):
         return self._auto_clean

--- a/nautilus_terminal/schemas/org.flozz.nautilus-terminal.gschema.xml
+++ b/nautilus_terminal/schemas/org.flozz.nautilus-terminal.gschema.xml
@@ -60,10 +60,15 @@
       <default>'Off'</default>
       <summary>Automaitly clean terminal after each 'cd' command</summary>
       <description>
-        Soft Mode - clears terminal screen keeping scrollback (like Ctrl+L shortcut)  
+        Soft Mode - clears terminal screen keeping scrollback (like Ctrl+l shortcut).
 
-        Hard Mode - clears terminal including scrollback (like command 'clear')
+        Hard Mode - clears terminal including scrollback (like command 'clear').
       </description>
+    </key>
+    <key name="auto-cut-user-input" type="b">
+      <default>true</default>
+      <summary>Automaitly cut user input from terminal before applying 'cd' command</summary>
+      <description>This feature uses Ctrl+e and Ctrl+u shortcuts to remove user input. This won't work in vi-mode and may be incompatible with some shells.</description>
     </key>
   </schema>
 </schemalist>

--- a/nautilus_terminal/schemas/org.flozz.nautilus-terminal.gschema.xml
+++ b/nautilus_terminal/schemas/org.flozz.nautilus-terminal.gschema.xml
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist>
+  <enum id="org.flozz.nautilus-terminal.clean-mode">
+    <value nick="Off" value="0"/>
+    <value nick="Ctrl+L shortcut" value="1"/>
+    <value nick="clear command" value="2"/>
+  </enum>
   <schema id="org.flozz.nautilus-terminal" path="/org/flozz/nautilus-terminal/">
     <key name="default-show-terminal" type="b">
       <default>true</default>
@@ -50,6 +55,14 @@
       <default>false</default>
       <summary>Is Nautilus Terminal focused in new Nautilus windows</summary>
       <description>Enabled "default-show-terminal" is required</description>
+    </key>
+    <key name="auto-clean" enum="org.flozz.nautilus-terminal.clean-mode">
+      <default>'Off'</default>
+      <summary>Automaitly clean terminal after each 'cd' command</summary>
+      <description>
+        Ctrl+L shortcut - clears terminal screen keeping scrollback
+        clear command - clears terminal including scrollback
+      </description>
     </key>
   </schema>
 </schemalist>

--- a/nautilus_terminal/schemas/org.flozz.nautilus-terminal.gschema.xml
+++ b/nautilus_terminal/schemas/org.flozz.nautilus-terminal.gschema.xml
@@ -2,8 +2,8 @@
 <schemalist>
   <enum id="org.flozz.nautilus-terminal.clean-mode">
     <value nick="Off" value="0"/>
-    <value nick="Ctrl+L shortcut" value="1"/>
-    <value nick="clear command" value="2"/>
+    <value nick="Soft" value="1"/>
+    <value nick="Hard" value="2"/>
   </enum>
   <schema id="org.flozz.nautilus-terminal" path="/org/flozz/nautilus-terminal/">
     <key name="default-show-terminal" type="b">
@@ -60,8 +60,9 @@
       <default>'Off'</default>
       <summary>Automaitly clean terminal after each 'cd' command</summary>
       <description>
-        Ctrl+L shortcut - clears terminal screen keeping scrollback
-        clear command - clears terminal including scrollback
+        Soft Mode - clears terminal screen keeping scrollback (like Ctrl+L shortcut)  
+
+        Hard Mode - clears terminal including scrollback (like command 'clear')
       </description>
     </key>
   </schema>


### PR DESCRIPTION
Fix for #16 issue. Two new things here.

1. Now current user input will be cut from terminal before each directory change.

This will prevent errors after appending ' cd ...' to something already typed in terminal.
I'm doing this by triggering 'ctrl-u' shortcut which cuts current user input in some separate buffer.

I tried to restore content after directory change but I have some problem with detecting is there any user input at all. Without this information I can't apply 'ctrl-y' shortcut (which puts content from buffer back to terminal) in all situations. In case when there was no any user input 'ctrl-u' won't clear that buffer. And 'ctrl-y' will fill terminal with something that could be in that buffer before.

But anyway user still can restore it manually by Ctrl-y shortcut.

2. New 'auto-clean' setting for cleaning terminal after changing directory. It has 2 modes. One cleans like ctrl+l shortcut, which keeps scrollback. And another one using 'clear' command which removes scrollback.