### PR TITLE
Allow detection of nautilus-terminal from the shell

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -292,6 +292,24 @@ Once done, reinstall the schema with one of the following commands::
 Finally restart Nautilus.
 
 
+Detect if running inside nautilus-terminal
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+To detect whether the shell is running inside nautilus-terminal, there is an environment variable
+exposed when executing the shell:
+
+   INSIDE_NAUTILUS_PYTHON=1
+
+It is useful in case you want to avoid running things inside the nautilus-terminal:
+
+   ~/.bashrc:
+
+   # Run termux only if not inside nautilus-terminal
+   if [ -z "$INSIDE_NAUTILUS_PYTHON" ]; then
+     tmux -attach
+   fi
+
+
 Reporting an issue
 ~~~~~~~~~~~~~~~~~~
 

--- a/nautilus_terminal/nautilus_terminal.py
+++ b/nautilus_terminal/nautilus_terminal.py
@@ -493,7 +493,7 @@ class NautilusTerminal(object):
             Vte.PtyFlags.DEFAULT,
             self._cwd,
             [shell],
-            None,
+            ['INSIDE_NAUTILUS_PYTHON=1'],
             GLib.SpawnFlags.SEARCH_PATH,
             None,
             None,


### PR DESCRIPTION
Please consider my pull request which:
- Fixes the env variable INSIDE_NAUTILUS_PYTHON not being exposed within the shell spawned by nautilus-terminal. Done that just by forcing it into environment of spawn_sync() call. I do not know if this variable was ever provided by Nautilus-extension framework, but it's not on OS.
- Updated the docu to aknowledge this detection possibility