### PR TITLE
Add option for custom color palette and bold text as bright

### DIFF
--- a/nautilus_terminal/nautilus_terminal.py
+++ b/nautilus_terminal/nautilus_terminal.py
@@ -310,7 +310,7 @@ class NautilusTerminal(object):
             + TERMINAL_BORDER_WIDTH * 2,
         )
 
-        # Terminal colors
+        # Terminal foreground and background colors
 
         fg_color = (255, 255, 255)
         bg_color = (0, 0, 0)
@@ -324,23 +324,43 @@ class NautilusTerminal(object):
         if color_helpers.is_color(settings_bg_color):
             bg_color = color_helpers.parse_color_string(settings_bg_color)
 
-        self._ui_terminal.set_color_foreground(
-            Gdk.RGBA(
-                fg_color[0] / 255.0,
-                fg_color[1] / 255.0,
-                fg_color[2] / 255.0,
-                1,
-            )
+        foreground = Gdk.RGBA(
+            fg_color[0] / 255.0,
+            fg_color[1] / 255.0,
+            fg_color[2] / 255.0,
+            1,
+        )
+        background = Gdk.RGBA(
+            bg_color[0] / 255.0,
+            bg_color[1] / 255.0,
+            bg_color[2] / 255.0,
+            1,
         )
 
-        self._ui_terminal.set_color_background(
-            Gdk.RGBA(
-                bg_color[0] / 255.0,
-                bg_color[1] / 255.0,
-                bg_color[2] / 255.0,
-                1,
-            )
-        )
+        # Terminal color palette
+
+        settings_color_palette = self._settings.get_strv("color-palette")
+
+        palette_colors = []
+        if any(settings_color_palette) and len(settings_color_palette) in (8, 16, 232, 256):
+            for color_code in settings_color_palette:
+                if not color_helpers.is_color(color_code):
+                    color_code = 'White'  # Invalid colors default to white
+
+                color = color_helpers.parse_color_string(color_code)
+                color_rgba = Gdk.RGBA(
+                    color[0] / 255.0,
+                    color[1] / 255.0,
+                    color[2] / 255.0,
+                    1
+                )
+                palette_colors.append(color_rgba)
+
+        self._ui_terminal.set_colors(foreground, background, palette_colors)
+
+        # Bold text as bright
+
+        self._ui_terminal.set_bold_is_bright(self._settings.get_boolean("bold-is-bright"))
 
         # File drag & drop support
 

--- a/nautilus_terminal/nautilus_terminal.py
+++ b/nautilus_terminal/nautilus_terminal.py
@@ -342,17 +342,22 @@ class NautilusTerminal(object):
         settings_color_palette = self._settings.get_strv("color-palette")
 
         palette_colors = []
-        if any(settings_color_palette) and len(settings_color_palette) in (8, 16, 232, 256):
+        if any(settings_color_palette) and len(settings_color_palette) in (
+            8,
+            16,
+            232,
+            256,
+        ):
             for color_code in settings_color_palette:
                 if not color_helpers.is_color(color_code):
-                    color_code = 'White'  # Invalid colors default to white
+                    color_code = "White"  # Invalid colors default to white
 
                 color = color_helpers.parse_color_string(color_code)
                 color_rgba = Gdk.RGBA(
                     color[0] / 255.0,
                     color[1] / 255.0,
                     color[2] / 255.0,
-                    1
+                    1,
                 )
                 palette_colors.append(color_rgba)
 
@@ -360,7 +365,9 @@ class NautilusTerminal(object):
 
         # Bold text as bright
 
-        self._ui_terminal.set_bold_is_bright(self._settings.get_boolean("bold-is-bright"))
+        self._ui_terminal.set_bold_is_bright(
+            self._settings.get_boolean("bold-is-bright")
+        )
 
         # File drag & drop support
 

--- a/nautilus_terminal/schemas/org.flozz.nautilus-terminal.gschema.xml
+++ b/nautilus_terminal/schemas/org.flozz.nautilus-terminal.gschema.xml
@@ -1,15 +1,15 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist>
   <enum id="org.flozz.nautilus-terminal.clean-mode">
-    <value nick="Off" value="0"/>
-    <value nick="Soft" value="1"/>
-    <value nick="Hard" value="2"/>
+    <value nick="Off" value="0" />
+    <value nick="Soft" value="1" />
+    <value nick="Hard" value="2" />
   </enum>
   <schema id="org.flozz.nautilus-terminal" path="/org/flozz/nautilus-terminal/">
     <key name="default-show-terminal" type="b">
       <default>true</default>
       <summary>Is Nautilus Terminal visible in new Nautilus windows</summary>
-      <description/>
+      <description />
     </key>
     <key name="use-custom-command" type="b">
       <default>false</default>
@@ -45,6 +45,24 @@
       <default>"#ffffff"</default>
       <summary>Terminal text color</summary>
       <description>The color of the terminal text (Hexadecimal notation. E.g. "#FFFFFF", "white")</description>
+    </key>
+    <key name="color-palette" type="as">
+      <default>['', '', '', '', '', '', '', '',
+                '', '', '', '', '', '', '', '']</default>
+      <summary>Color palette of the terminal text</summary>
+      <description>
+        16 colors, the first 8 being the standard colors, and the remaining 8 their bright counterparts.
+        All colors should be specified, accepting hexadecimal values ('#FF0000') or names ('red').
+
+        Other accepted amounts of values: 8, 232, 256.
+        If no values are specified or the amount of values is wrong, default colors will be used.
+        Note that invalid colors will default to white.
+      </description>
+    </key>
+    <key name="bold-is-bright" type="b">
+      <default>false</default>
+      <summary>Whether bold colors are also bright</summary>
+      <description>If true, setting bold on the first 8 colors also switches to their bright variants.</description>
     </key>
     <key name="custom-font" type="s">
       <default>""</default>


### PR DESCRIPTION
**Added an array of strings in the config schema to input the color palette using hexadecimals or names**:
It is the only way I could find to implement this in the current schema configuration file. Could be a temporary addition until the settings GUI is implemented .

**Added a boolean to turn bold text's color to the bright counterparts.**
An addition I personally think is useful for darker color palettes.